### PR TITLE
black and white tracks are not same size - stroke-size issue

### DIFF
--- a/encoder_disk_generator.py
+++ b/encoder_disk_generator.py
@@ -280,8 +280,8 @@ class EncoderDiskGenerator(inkex.Effect):
 
 		# Line style for the encoder segments
 		line_style   = { 
-			'stroke'		: 	'black',
-			'stroke-width'	:	'1',
+			'stroke'		: 	'white',
+			'stroke-width'	:	'0',
 			'fill'			:	'black'
 		}
 


### PR DESCRIPTION
Hello,

I noticed that the white parts of the encoder-disk are not the same size as the black parts. (Nor the track-part-lengths nor the distance-between-tracks and tracks-width). Probably it is a bug, and I think, I can solve it very easily with setting the stroke size to zero.
I checked measure it in Inkscape by the straight-lines tool (shift F6) and now it seems nearly the same size.

To tell you the truth, I just started to use inkscape and python yesterday, and I did not understand your code deeply, so feel free not to agree with me.

Thank you for your great plugin, it helped me a lot.
