### PR TITLE
center-hole marker was invisible - set stroke black and thin

### DIFF
--- a/encoder_disk_generator.py
+++ b/encoder_disk_generator.py
@@ -255,7 +255,7 @@ class EncoderDiskGenerator(inkex.Effect):
 
 		# Attributes for the guide hole in the center hole, then create it
 		attributes = {
-			'style'     : simplestyle.formatStyle({'stroke':'white','fill':'white'}),
+			'style'     : simplestyle.formatStyle({'stroke':'black','fill':'white', 'stroke-width':'0.1'}),
 			'r'         : '1'
 		}
 		circle_elements.append(attributes)


### PR DESCRIPTION
Hello,

The center hole was invisible when I created a BRGC encoder disk. I just set the stroke to black and thin, so I can see the center hole.

Thank you for you plugin
