### PR TITLE
Fix to incorrect gap used in single track encoder

### DIFF
--- a/encoder_disk_generator.py
+++ b/encoder_disk_generator.py
@@ -196,8 +196,8 @@ class EncoderDiskGenerator(inkex.Effect):
 		segments = []
 		resolution = 360.0/(cutouts*2*sensors)
 		current_angle = 0.0
+		added_angle = ((2*cutouts+1)*resolution)
 		for n in range(cutouts):
-			added_angle = ((1*cutouts+1)*resolution)
 			current_segment_size = ((n*2+2)*cutouts+1)*resolution
 			segments.append(self.drawSegment(line_style, current_angle, 
 							current_segment_size, encoder_diameter, track_width))


### PR DESCRIPTION
.Added_angle didn't need to be inside the loop as it doesn't change and was being calculated incorrectly as well. It needs to be 2 times the number of cutouts + 1 not just the number of cutouts + 1 wide.
